### PR TITLE
Remove adding sound to registry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,12 +13,9 @@ repositories {
 }
 
 dependencies {
-    // To change the versions see the gradle.properties file
     minecraft("com.mojang:minecraft:${project.property("minecraft_version")}")
     mappings(loom.officialMojangMappings())
     modImplementation("net.fabricmc:fabric-loader:${project.property("loader_version")}")
-
-    modImplementation(fabricApi.module("fabric-registry-sync-v0", project.property("fabric_api_version") as String))
 
     modApi("net.uku3lig:ukulib:${project.property("ukulib_version")}")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,4 @@ mod_version=0.10.0
 maven_group=ru.berdinskiybear.armorhud
 archives_base_name=ukus-armor-hud
 #Dependencies
-fabric_api_version=0.139.4+1.21.11
 ukulib_version=1.10.0+1.21.11

--- a/src/main/java/ru/berdinskiybear/armorhud/ArmorHudMod.java
+++ b/src/main/java/ru/berdinskiybear/armorhud/ArmorHudMod.java
@@ -7,8 +7,6 @@ import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.Rect2i;
-import net.minecraft.core.Registry;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.sounds.SoundEvent;
@@ -181,7 +179,5 @@ public final class ArmorHudMod implements ModInitializer {
     public void onInitialize() {
         Ukutils.registerToggleBind(new KeyMapping("armorhud.keybind.toggle", GLFW.GLFW_KEY_UNKNOWN, KeyMapping.Category.register(Identifier.fromNamespaceAndPath(MOD_ID, "key"))),
                 () -> manager.getConfig().isEnabled(), b -> manager.getConfig().setEnabled(b), Component.translatable("armorhud.keybind.toggle.msg"));
-
-        Registry.register(BuiltInRegistries.SOUND_EVENT, ARMOR_BREAKING_SOUND.location(), ARMOR_BREAKING_SOUND);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,8 +33,7 @@
     "minecraft": ">=1.21.11",
     "fabricloader": ">=0.17",
     "ukulib": "^1.10.0",
-    "fabric-resource-loader-v1": "*",
-    "fabric-registry-sync-v0": "*"
+    "fabric-resource-loader-v1": "*"
   },
   "breaks": {
     "armor_hud": "*"


### PR DESCRIPTION
Fixes #20 

I've tested and the sound still plays when its suppose to and you can join a LAN world with someone using it. I think the only thing that matters is it being registered correctly in a resourcepack and referenced correctly when the sound is played, which it is.