### PR TITLE
Hide durability when not needed

### DIFF
--- a/src/main/java/ru/berdinskiybear/armorhud/mixin/MixinGui.java
+++ b/src/main/java/ru/berdinskiybear/armorhud/mixin/MixinGui.java
@@ -156,7 +156,7 @@ public abstract class MixinGui {
                 x += SIZE;
             }
 
-            if (config.getDurabilityDisplay() != ArmorHudConfig.DurabilityDisplay.BAR && !stack.isEmpty()) {
+            if (config.getDurabilityDisplay() != ArmorHudConfig.DurabilityDisplay.BAR && !stack.isEmpty() && stack.isDamageableItem()) {
                 String dura = switch (config.getDurabilityDisplay()) {
                     case NUMERIC -> String.valueOf(stack.getMaxDamage() - stack.getDamageValue());
                     case PERCENTAGE -> {


### PR DESCRIPTION
This is mostly when the dura display is either numeric or percentage and you're using something like a hoplite custom helmet. You could make it so unbreakable pieces display their current damage in case for some reason it became unbreakable after taking damage, and "undamageable" is kinda of a bad name, though I had no other ideas